### PR TITLE
Omit lines that use pandoc 2.0's markdown divs

### DIFF
--- a/exportMarkdownReferences.sh
+++ b/exportMarkdownReferences.sh
@@ -22,7 +22,7 @@ read refs
 command -v pandoc >/dev/null 2>&1 || { echo "Cannot find pandoc in path. Edit the PATH variable in citeServiceTemplate-pandoc-bib-script.sh"; exit 0;}
 
 # Pass the list of pandoc-formated references to pandoc.
-echo "$refs" | pandoc -t markdown-citations --wrap=none --bibliography="$bibfile" 2>/dev/null | tail -n+5 | grep -v "</div>"
+echo "$refs" | pandoc -t markdown-citations --wrap=none --bibliography="$bibfile" 2>/dev/null | tail -n+5 | grep -v ":::"
 
 exit 0
 


### PR DESCRIPTION
Nowadays pandoc includes extra metadata to delineate divs in bibliographies. It used to use HTML like `<div>`, but now it uses `:::`. For instance, after exporting two entries with `pandoc -t markdown-citations --wrap=none`, this is the resulting output:

```text
(Blackwell and Glynn 2018; Cinelli and Hazlett 2020)

::: {#refs .references .hanging-indent}
::: {#ref-BlackwellGlynn:2018}
Blackwell, Matthew, and Adam N. Glynn. 2018. "How to Make Causal Inferences with Time-Series Cross-Sectional Data Under Selection on Observables." *American Political Science Review* 112 (4): 1067--82. <https://doi.org/10.1017/s0003055418000357>.
:::

::: {#ref-CinelliHazlett:2020}
Cinelli, Carlos, and Chad Hazlett. 2020. "Making Sense of Sensitivity: Extending Omitted Variable Bias." *Journal of the Royal Statistical Society: Series B (Statistical Methodology)* 82 (1): 39--67. <https://doi.org/10.1111/rssb.12348>.
:::
:::
```

The `tail -n+5` part of the pandoc command in `exportMarkdownReferences.sh` takes care of the first few lines with the parenthetical citations, but the old `grep -v "</div>"` part of the command doesn't do anything anymore and the resulting Markdown text includes all the lines that start with `:::`.

This change to the pandoc command omits all lines that start with `:::`, resulting in this output:

```text
Blackwell, Matthew, and Adam N. Glynn. 2018. "How to Make Causal Inferences with Time-Series Cross-Sectional Data Under Selection on Observables." *American Political Science Review* 112 (4): 1067--82. <https://doi.org/10.1017/s0003055418000357>.

Cinelli, Carlos, and Chad Hazlett. 2020. "Making Sense of Sensitivity: Extending Omitted Variable Bias." *Journal of the Royal Statistical Society: Series B (Statistical Methodology)* 82 (1): 39--67. <https://doi.org/10.1111/rssb.12348>.
```